### PR TITLE
Fixed grant deletion error in admin dashboard

### DIFF
--- a/src/server/api/routers/grants.ts
+++ b/src/server/api/routers/grants.ts
@@ -36,7 +36,7 @@ export const grantsRouter = createTRPCRouter({
   deleteGrant: adminProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      ctx.prisma.uploads.deleteMany({
+      await ctx.prisma.uploads.deleteMany({
         where: {
           grantId: input.id,
         }

--- a/src/server/api/routers/grants.ts
+++ b/src/server/api/routers/grants.ts
@@ -36,6 +36,11 @@ export const grantsRouter = createTRPCRouter({
   deleteGrant: adminProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      ctx.prisma.uploads.deleteMany({
+        where: {
+          grantId: input.id,
+        }
+      });
       return ctx.prisma.grant.delete({
         where: {
           id: input.id,


### PR DESCRIPTION
The issue was with grants that had uploads, so deleting the grants would violate the relation between them.